### PR TITLE
Fix error: Attempt to invoke virtual method 'double java.lang.Double.…

### DIFF
--- a/lib/QRScanner.js
+++ b/lib/QRScanner.js
@@ -56,10 +56,10 @@ export class QRScannerRectView extends Component {
   
   constructor(props){
     super(props);
-    this.innerRectStyle = Object.assign(defaultRectStyle, props.rectStyle);
-    this.innerCornerStyle = Object.assign(defaultCornerStyle, props.cornerStyle);
-    this.innerScanBarStyle = Object.assign(defaultScanBarStyle, props.scanBarStyle);
-    this.innerHintTextStyle = Object.assign(defaultHintTextStyle, props.hintTextStyle);
+    this.innerRectStyle = Object.assign({}, defaultRectStyle, props.rectStyle);
+    this.innerCornerStyle = Object.assign({}, defaultCornerStyle, props.cornerStyle);
+    this.innerScanBarStyle = Object.assign({}, defaultScanBarStyle, props.scanBarStyle);
+    this.innerHintTextStyle = Object.assign({}, defaultHintTextStyle, props.hintTextStyle);
   }
   
   componentDidMount(){


### PR DESCRIPTION
…doubleValue()' an a null object reference

https://github.com/MarnoDev/react-native-qrcode-scanner-view/issues/72